### PR TITLE
Fix typing

### DIFF
--- a/fs_mol/data/file_reader_iterable.py
+++ b/fs_mol/data/file_reader_iterable.py
@@ -4,7 +4,7 @@ import time
 from multiprocessing import Queue, Process, Event
 from multiprocessing.synchronize import Event as EventType
 from queue import Empty
-from typing import List, Iterator, TypeVar, Callable, Iterable
+from typing import List, Iterator, TypeVar, Callable, Iterable, Union, Type
 
 import numpy as np
 from dpu_utils.utils import RichPath


### PR DESCRIPTION
Small change to get maml_train.py to run consistently, including on AzureML. Queue[RichPath] was not accepted as a type (non-subscriptable). 