### PR TITLE
Inline finetune_and_eval_on_task

### DIFF
--- a/fs_mol/utils/maml_train_utils.py
+++ b/fs_mol/utils/maml_train_utils.py
@@ -11,7 +11,7 @@ import tensorflow as tf
 from tf2_gnn.cli_utils.model_utils import _get_name_to_variable_map, load_weights_verbosely
 from tf2_gnn.cli_utils.dataset_utils import get_model_file_path
 
-from fs_mol.data import DataFold, FSMolDataset, FSMolTaskSample, MoleculeDatapoint
+from fs_mol.data import DataFold, FSMolDataset, FSMolTaskSample
 from fs_mol.models.metalearning_graph_binary_classification import (
     MetalearningGraphBinaryClassificationTask,
 )


### PR DESCRIPTION
After #8, MAML's `finetune_and_eval_on_task` became almost synonymous to `eval_model_by_finetuning_on_task` (modulo additional logging and tiny differences in how the data is passed in). Inlining one into the other to get rid of this unnecessary complexity.