### PR TITLE
fix(multitask_train): excess arg to train loop

### DIFF
--- a/fs_mol/multitask_train.py
+++ b/fs_mol/multitask_train.py
@@ -292,7 +292,6 @@ def main():
             max_num_graphs=args.batch_size,
         ),
         valid_fn=valid_fn,
-        output_folder=out_dir,
         metric_to_use=args.metric_to_use,
         max_num_epochs=args.num_epochs,
         patience=args.patience,


### PR DESCRIPTION
Fix to prevent multitask_train from breaking due to an unused argument in the train_loop() call. 

Do we want to occasionally save intermediate best validation models?