### PR TITLE
Set author identity for commits generated from the automatic pipeline

### DIFF
--- a/pipelines/push-to-internal.yml
+++ b/pipelines/push-to-internal.yml
@@ -13,8 +13,8 @@ pool:
 steps:
 - script: |
     BRANCH_NAME=`echo $BUILD_SOURCEBRANCH | sed -e 's!^refs/heads/!!'`
-    git config user.name "ADO-Pipeline"
-    git config user.email "pipeline@ado.com"
+    git config user.name "ADO Pipeline"
+    git config user.email "t-mestan@microsoft.com"
     git remote add internal https://msrcambridge:$(GitHub_FSMol_Sync_PAT)@dev.azure.com/msrcambridge/GenChem/_git/FS-Mol
     git remote update
     git checkout -b ${BRANCH_NAME}/merged

--- a/pipelines/push-to-internal.yml
+++ b/pipelines/push-to-internal.yml
@@ -13,6 +13,8 @@ pool:
 steps:
 - script: |
     BRANCH_NAME=`echo $BUILD_SOURCEBRANCH | sed -e 's!^refs/heads/!!'`
+    git config user.name "ADO-Pipeline"
+    git config user.email "pipeline@ado.com"
     git remote add internal https://msrcambridge:$(GitHub_FSMol_Sync_PAT)@dev.azure.com/msrcambridge/GenChem/_git/FS-Mol
     git remote update
     git checkout -b ${BRANCH_NAME}/merged


### PR DESCRIPTION
This PR adds author identity to automatically generated merge commits, as git is complaining that it's missing.