### PR TITLE
Add flag to skip per-node projection for torch models.

### DIFF
--- a/fs_mol/modules/gnn.py
+++ b/fs_mol/modules/gnn.py
@@ -61,6 +61,8 @@ def add_gnn_model_arguments(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--num_gnn_layers", type=int, default=10, help="Number of GNN layers to use."
     )
+    parser.add_argument("--skip-node-embedding", action="store_true",
+                        help="Skip learning a per-node embedding. Input dim then equals model dim.")
 
 
 def make_gnn_config_from_args(args: argparse.Namespace) -> GNNConfig:


### PR DESCRIPTION
Add a flag to optionally skip the node projection in GNN models.

This enables researchers to use pre-trained node embeddings rather than learning node embeddings on the FS-Mol dataset. 

To use pre-trained embeddings, simply convert the FS-Mol dataset field MoleculeDatapoint.graph.node_features to the pre-trained embedding of size equal to the model's internal node representation dimension.